### PR TITLE
Add the ability to specify unwanted pokemon instead of wanted pokemon

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@ To generate a token for sending yourself notifications using the Pushbullet API,
 
 ## Config File
 Instead of from the command-line, all arguments are read from a `config.json` file. In addition to all of the options laid out [here](https://github.com/AHAAAAAAA/PokemonGo-Map/wiki/Usage), I've introduced two required fields: `pushbullet`, your Pushbullet API key, and `notify`, a comma-separated list of the Pokemon that you'd like to receive Pushbullet notifications for.
+As an alernative to 'notify', you may also make use of a field called 'do_not_notify'. If the 'do_not_notify' field is present and the 'notify' field is not present, you will be notified for ALL pokemon except the ones in the 'do_not_notify' field.
 
-Here's a sample `config.json`:
+Here's a sample `config.json` using the 'notify' field:
 
 ```
 {
@@ -18,6 +19,20 @@ Here's a sample `config.json`:
   "step_limit": 5,
   "location": "742 Evergreen Terrace, Arlington, VA",
   "notify": "dratini,magnemite,electabuzz,hitmonchan,hitmonlee,chansey,lapras,snorlax,porygon,mew,mewtwo,moltres,zapdos,articuno,ditto,seel,gyarados,cubone",
+  "pushbullet": "o.XyDeiVeYuM5eSv2ssy7AlFGLDl4ajEXj"
+}
+```
+
+Here's a sample `config.json` using the 'do_not_notify' field:
+
+```
+{
+  "auth_service": "google",
+  "username": "myemailuser",
+  "password": "pikachu123",
+  "step_limit": 5,
+  "location": "742 Evergreen Terrace, Arlington, VA",
+  "do_not_notify": "rattata,raticate,pidgey,pidgeotto,venonat,zubat,golbat,magikarp,weedle,kakuna,caterpie,metapod",
   "pushbullet": "o.XyDeiVeYuM5eSv2ssy7AlFGLDl4ajEXj"
 }
 ```

--- a/main.py
+++ b/main.py
@@ -445,19 +445,67 @@ def get_args():
         "debug": False,
         "display_gym": False,
         "display_pokestop": False,
+        "do_not_notify": None,
         "host": "127.0.0.1",
         "ignore": None,
         "locale": "en",
+        "location": None,
+        "notify": None,
         "only": None,
         "onlylure": False,
+        "password": None,
         "port": 5000,
-        "step_limit": 4
+        "pushbullet": None,
+        "step_limit": 4,
+        "username": None
+    }
+    
+    INTEGER_STR = "int"
+    BOOLEAN_STR = "bool"
+    STRING_STR = "str"
+    default_args_type = {
+        "DEBUG": BOOLEAN_STR,
+        "ampm_clock": BOOLEAN_STR,
+        "auth_service": STRING_STR,
+        "auto_refresh": INTEGER_STR,
+        "china": BOOLEAN_STR,
+        "debug": BOOLEAN_STR,
+        "display_gym": BOOLEAN_STR,
+        "display_pokestop": BOOLEAN_STR,
+        "do_not_notify": STRING_STR,
+        "host": STRING_STR,
+        "ignore": STRING_STR,
+        "locale": STRING_STR,
+        "location": STRING_STR,
+        "notify": STRING_STR,
+        "only": STRING_STR,
+        "onlylure": BOOLEAN_STR,
+        "password": STRING_STR,
+        "port": INTEGER_STR,
+        "pushbullet": STRING_STR,
+        "step_limit": INTEGER_STR,
+        "username": STRING_STR
     }
     # load config file
     with open('config.json') as data_file:
         data = json.load(data_file)
         for key in data:
-            default_args[key] = str(data[key])
+            if key not in default_args_type:
+                print key
+                raise LookupError('Arguments Type List Needs Updated')
+                
+            if default_args_type[key] == INTEGER_STR:
+                default_args[key] = int(data[key])
+                
+            elif default_args_type[key] == BOOLEAN_STR:
+                default_args[key] = data[key]
+                
+            else:
+                if default_args_type[key] != STRING_STR:
+                    import warnings
+                    warnings.warn( 'Unsupported Default Args Type' )
+            
+                default_args[key] = str(data[key])
         # create namespace obj
         namespace = argparse.Namespace()
         for key in default_args:

--- a/main.py
+++ b/main.py
@@ -19,6 +19,7 @@ import threading
 import werkzeug.serving
 import pokemon_pb2
 import time
+import warnings
 from google.protobuf.internal import encoder
 from google.protobuf.message import DecodeError
 from s2sphere import *
@@ -491,8 +492,7 @@ def get_args():
         data = json.load(data_file)
         for key in data:
             if key not in default_args_type:
-                print key
-                raise LookupError('Arguments Type List Needs Updated')
+                warnings.warn( 'Config Item ' + key + 'Does Not Have a Default Type' )
                 
             if default_args_type[key] == INTEGER_STR:
                 default_args[key] = int(data[key])
@@ -502,7 +502,6 @@ def get_args():
                 
             else:
                 if default_args_type[key] != STRING_STR:
-                    import warnings
                     warnings.warn( 'Unsupported Default Args Type' )
             
                 default_args[key] = str(data[key])

--- a/notifier.py
+++ b/notifier.py
@@ -9,17 +9,26 @@ sys.setdefaultencoding('utf8')
 
 pushbullet_client = None
 wanted_pokemon = None
+unwanted_pokemon = None
 
 # Initialize object
 def init():
-    global pushbullet_client, wanted_pokemon
+    global pushbullet_client, wanted_pokemon, unwanted_pokemon
     # load pushbullet key
     with open('config.json') as data_file:
         data = json.load(data_file)
         # get list of pokemon to send notifications for
-        wanted_pokemon = _str( data["notify"] ) . split(",")
-        # transform to lowercase
-        wanted_pokemon = [a.lower() for a in wanted_pokemon]
+        if "notify" in data:
+            wanted_pokemon = _str( data["notify"] ) . split(",")
+            
+            # transform to lowercase
+            wanted_pokemon = [a.lower() for a in wanted_pokemon]
+        #get list of pokemon to NOT send notifications for
+        if "do_not_notify" in data:
+            unwanted_pokemon = _str( data["do_not_notify"] ) . split(",")
+            
+            # transform to lowercase
+            unwanted_pokemon = [a.lower() for a in unwanted_pokemon]
         # get api key
         api_key = _str( data["pushbullet"] )
         if api_key:
@@ -35,7 +44,12 @@ def pokemon_found(pokemon):
     # get name
     pokename = _str(pokemon["name"]).lower()
     # check array
-    if not pushbullet_client or not pokename in wanted_pokemon: return
+    if not pushbullet_client:
+        return
+    elif wanted_pokemon != None and not pokename in wanted_pokemon:
+        return
+    elif wanted_pokemon == None and unwanted_pokemon != None and pokename in unwanted_pokemon:
+        return
     # notify
     print "[+] Notifier found pokemon:", pokename
 


### PR DESCRIPTION
This pull request includes a
- [ ] Bug fix
- [X] New feature
- [ ] Translation

The following changes were made
- Add the ability to specify a list of pokemon to NOT be notified for in the config file. This will only be used when this list is present AND the list of pokemon to notify for (the "notify" option) is not present. If the "notify" list is present, this new list will not be used. Here's a sample config using the new "do_not_notify" option:

{
  "auth_service": "google",
  "username": "your_email_here",
  "password": "your_password_here",
  "step_limit": 5,
  "location": "1 White House Lane",
  "do_not_notify": "rattata,raticate,pidgey,pidgeotto,pidgeot,weedle,kakuna,caterpie,metapod,zubat,golbat,venonat,oddish,magikarp,spearow,paras,ekans,goldeen,doduo,pinsir,poliwag",
  "pushbullet": "o.m5fgAZaBFiZ0gHrNg21ZLFOKZStckql"
}
